### PR TITLE
Rename parameter fields as per specification

### DIFF
--- a/src/device/emulator/app_telemetry/start.js
+++ b/src/device/emulator/app_telemetry/start.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (startDeviceTelemetryRequest){
 	// Response templates
 	
 	StartApplicationTelemetryResponse = {

--- a/src/device/emulator/app_telemetry/stop.js
+++ b/src/device/emulator/app_telemetry/stop.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (stopDeviceTelemetryRequest){
 	// Response templates
 	
 StopApplicationTelemetryResponse = { status : 200 }

--- a/src/device/emulator/applications/exit.js
+++ b/src/device/emulator/applications/exit.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (exitApplicationRequest){
 	// Response templates
 	
 	ExitApplicationResponse = {

--- a/src/device/emulator/applications/launch.js
+++ b/src/device/emulator/applications/launch.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (launchApplicationRequest){
 	// Response templates
 	
 LaunchApplicationResponse = { status : 200 }

--- a/src/device/emulator/applications/launch_with_content.js
+++ b/src/device/emulator/applications/launch_with_content.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (launchApplicationWithContentRequest){
 	// Response templates
 	
 	GetApplicationStateResponse = {

--- a/src/device/emulator/applications/list.js
+++ b/src/device/emulator/applications/list.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (applicationListRequest){
 	// Response templates
 	
 	interface Application {

--- a/src/device/emulator/device/info.js
+++ b/src/device/emulator/device/info.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (deviceInfoRequest){
 	// Response templates
 	
 	enum NetworkInterfaceType{

--- a/src/device/emulator/device_telemetry/start.js
+++ b/src/device/emulator/device_telemetry/start.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (startDeviceTelemetryRequest){
 	// Response templates
 	
 	StartDeviceTelemetryResponse = {

--- a/src/device/emulator/device_telemetry/stop.js
+++ b/src/device/emulator/device_telemetry/stop.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (stopDeviceTelemetryRequest){
 	// Response templates
 	
 StopDeviceTelemetryResponse = { status : 200 }

--- a/src/device/emulator/discovery.js
+++ b/src/device/emulator/discovery.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (discoveryRequest){
 	// Response templates
 	
 	DiscoveryResponse = {

--- a/src/device/emulator/health_check/get.js
+++ b/src/device/emulator/health_check/get.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (healthCheckRequest){
 	// Response templates
 	
 	HealthCheckResponse = {

--- a/src/device/emulator/input/key/list.js
+++ b/src/device/emulator/input/key/list.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (listKeyRequest){
 	// Response templates
 	
 	KeyList = {

--- a/src/device/emulator/input/key_press.js
+++ b/src/device/emulator/input/key_press.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (keyPressRequest){
 	// Response templates
 	
 KeyPressResponse = { status : 200 }

--- a/src/device/emulator/input/long_key_press.js
+++ b/src/device/emulator/input/long_key_press.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (longKeyPressRequest){
 	// Response templates
 	
 KeyPressResponse = { status : 200 }

--- a/src/device/emulator/operations/list.js
+++ b/src/device/emulator/operations/list.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (operationsListRequest){
 	// Response templates
 	
 	ListSupportedOperationResponse = {

--- a/src/device/emulator/output/image.js
+++ b/src/device/emulator/output/image.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (outputImageRequest){
 	// Response templates
 	
 	OutputImageResponse = {

--- a/src/device/emulator/system/restart.js
+++ b/src/device/emulator/system/restart.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (restartRequest){
 	// Response templates
 	
 RestartResponse = { status : 200 }

--- a/src/device/emulator/system/settings/get.js
+++ b/src/device/emulator/system/settings/get.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (getSystemSettingsRequest){
 	// Response templates
 	
 	GetSystemSettingsResponse = {

--- a/src/device/emulator/system/settings/list.js
+++ b/src/device/emulator/system/settings/list.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (listSystemSettingsRequest){
 	// Response templates
 	
 	interface OutputResolution {

--- a/src/device/emulator/system/settings/set.js
+++ b/src/device/emulator/system/settings/set.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (setSystemSettingsRequest){
 	// Response templates
 	
 	SetSystemSettingsResponse = {

--- a/src/device/emulator/version.js
+++ b/src/device/emulator/version.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (versionRequest){
 	// Response templates
 	
 	Version = {

--- a/src/device/emulator/voice/list.js
+++ b/src/device/emulator/voice/list.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (voiceListRequest){
 	// Response templates
 	
 	interface VoiceSystem {

--- a/src/device/emulator/voice/send_audio.js
+++ b/src/device/emulator/voice/send_audio.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (sendAudioRequest){
 	// Response templates
 	
 VoiceRequestResponse = { status : 200 }

--- a/src/device/emulator/voice/send_text.js
+++ b/src/device/emulator/voice/send_text.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (sendTextRequest){
 	// Response templates
 	
 VoiceTextRequestResponse = { status : 200 }

--- a/src/device/emulator/voice/set.js
+++ b/src/device/emulator/voice/set.js
@@ -1,4 +1,4 @@
-async function process (requestParams){
+async function process (setVoiceSystemRequest){
 	// Response templates
 	
 	SetVoiceSystemResponse = {


### PR DESCRIPTION
As discussed, each parameter field has been renamed just as how it is defined / mentioned in the spec.

This allows the partner to cross-reference the request and see the expected properties they must have.