### PR TITLE
Handle unsupported operators gracefully and perform health-check during bridge add-device

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,13 +63,15 @@ function main() {
     const responseTopic = packet.properties.responseTopic;
     // Get correlationData property
     const correlationData = packet.properties.correlationData;
-    console.log("\nPublishing Response:");
-    console.log(`Topic: ${JSON.stringify(responseTopic)}`);
-    console.log(`Correlation Data: ${JSON.stringify({ properties: { correlationData }})}`);
+
     let response = await bridge.processMqttMessage(topic, message, this.mqttClient);
 
     if(response === null) return;
-    // No response to this message was warranted. When the design refactor is dropped this won't be necessary.
+    // No response to this message was warranted. When the listener design refactor is dropped this won't be necessary.
+
+    console.log("\nPublishing Response:");
+    console.log(`Topic: ${JSON.stringify(responseTopic)}`);
+    console.log(`Correlation Data: ${JSON.stringify({ properties: { correlationData }})}`);
 
     // Check if the response is an array or an individual entity
     if (Array.isArray(response)) {


### PR DESCRIPTION
Title describes the two major changes:

- Bridge now performs a health-check using the target partner implementation before add-device. This can be bypassed setting the field `skipValidation` to true with the request.
- Fixes a bug where the bridge did not handle unsupported DAB operators for devices gracefully.
- Add and update unit tests for Bridge.