### PR TITLE
Update message topic to be specific to the device

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dab-bridge-js",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Enables compatibility of multiple devices based on Reference Design Kit (RDK) with DAB (get-dab.com) through a network",
   "main": "bridge.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,10 @@
 {
   "name": "dab-bridge-js",
   "version": "1.0.2",
-  "description": "Enables compatibility of multiple devices based on Reference Design Kit (RDK) with DAB (get-dab.com) through a network",
+  "description": "Starter kit that can be used to develop a Device Automation Bus Bridge that is compliant with the DAB 2.0 specification.",
   "main": "bridge.js",
   "scripts": {
-    "build": "npm run build:emulator && npm run build:rdk",
-    "build:emulator": "TARGET_ENV=emulator node build.js",
-    "build:rdk": "TARGET_ENV=rdk node build.js",
+    "start": "node src/index.js",
     "test": "jest"
   },
   "license": "MIT",

--- a/src/interface/dab_device_interface.js
+++ b/src/interface/dab_device_interface.js
@@ -84,7 +84,7 @@ export class DabDeviceInterface {
             [
                 // this.client.publishRetained(`dab/${this.dabDeviceID}/${topics.DAB_VERSION_TOPIC}`, this.version()),
                 // this.client.publishRetained(`dab/${this.dabDeviceID}/${topics.DEVICE_INFO_TOPIC}`, await this.deviceInfo()),
-                this.notify("info", "DAB service is online")
+                this.notify("info", "DAB device is initialized.")
             ]
         );
 
@@ -97,7 +97,7 @@ export class DabDeviceInterface {
     async stop() {
         await Promise.all(
             [
-                this.notify("warn", "DAB service is shutting down"),
+                this.notify("warn", "DAB device is stopping."),
                 // this.client.clearRetained(`dab/${this.dabDeviceID}/${topics.DEVICE_INFO_TOPIC}`),
                 // this.client.clearRetained(`dab/${this.dabDeviceID}/${topics.DAB_VERSION_TOPIC}`)
             ]
@@ -110,7 +110,7 @@ export class DabDeviceInterface {
      * Publishes notifications to the message topic
      */
     async notify(level, message) {
-        return await this.client.publish(topics.DAB_MESSAGES,
+        return await this.client.publish(`dab/${this.dabDeviceID}/${topics.DAB_MESSAGES}`,
             {
                 timestamp: +new Date(),
                 level: level,


### PR DESCRIPTION
Currently the notify() API publishes to a generic MQTT topic `messages`, this PR updates this to be `dab/<device-id>/messages` so we have a trial per bridged device.