### PR TITLE
fix: handle chunked stop-collection responses in request flow

### DIFF
--- a/src/lib/mqtt_client/client.js
+++ b/src/lib/mqtt_client/client.js
@@ -22,6 +22,7 @@ import ee2pkg from 'eventemitter2';
 const { EventEmitter2 } = ee2pkg;
 import {getLogger} from "../util.js";
 const logger = getLogger()
+const STOP_COLLECTION_TOPIC = "system/logs/stop-collection";
 
 /**
  * @typedef {Object} Message
@@ -217,25 +218,68 @@ class Client {
 
     return new Promise((resolve, reject) => {
       let timer;
+      const isChunkedStopCollectionRequest = topic === STOP_COLLECTION_TOPIC;
+      const stopCollectionChunks = [];
+
+      const scheduleTimeout = () => {
+        timer = setTimeout(async function () {
+          subscription.end();
+          reject(new TimeoutError(`Failed to receive response from ${topic} within ${timeout}ms`));
+        }, timeout);
+      };
+
+      const resolveStopCollectionChunks = () => {
+        if (!stopCollectionChunks.length) {
+          return {status: 200};
+        }
+
+        const firstChunk = stopCollectionChunks[0];
+        const allArchives = stopCollectionChunks
+          .map((chunk) => chunk.logArchive)
+          .filter((archiveChunk) => typeof archiveChunk === "string");
+
+        return {
+          ...firstChunk,
+          logArchive: allArchives.join(""),
+          remainingChunks: 0
+        };
+      };
+
       const subscription = this.subscribe(responseTopic, async function (msg, pkg) {
         // Checks for the correct correlation Data.
         if (pkg.correlationData != requestId) {
           return;
         }
-        subscription.end();
-        clearTimeout(timer);
 
         if (msg.status > 299) {
+          subscription.end();
+          clearTimeout(timer);
           reject(msg);
         } else {
-          resolve(msg);
+          if (!isChunkedStopCollectionRequest) {
+            subscription.end();
+            clearTimeout(timer);
+            resolve(msg);
+            return;
+          }
+
+          stopCollectionChunks.push(msg);
+          const remainingChunks = msg.remainingChunks;
+          const hasMoreChunks = Number.isInteger(remainingChunks) && remainingChunks > 0;
+
+          if (hasMoreChunks) {
+            clearTimeout(timer);
+            scheduleTimeout();
+            return;
+          }
+
+          subscription.end();
+          clearTimeout(timer);
+          resolve(resolveStopCollectionChunks());
         }
       });
 
-      timer = setTimeout(async function () {
-        subscription.end();
-        reject(new TimeoutError(`Failed to receive response from ${topic} within ${timeout}ms`));
-      }, timeout);
+      scheduleTimeout();
 
       this.publish(requestTopic, payload, options).catch(reject);
     });


### PR DESCRIPTION
- add dedicated chunk aggregation for system/logs/stop-collection
- keep existing request behavior unchanged for all other operations
- continue receiving stop-collection chunks until remainingChunks reaches 0
- merge logArchive chunks into a single response payload before resolving
- refresh request timeout while waiting for additional chunks