### PR TITLE
fix: add DAB 2.1 operation-aware request timeouts

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -154,10 +154,10 @@ module.exports = {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  // testMatch: [
-  //   "**/__tests__/**/*.[jt]s?(x)",
-  //   "**/?(*.)+(spec|test).[tj]s?(x)"
-  // ],
+  testMatch: [
+    "**/?(*.)+(spec|test).[tj]s?(x)",
+    "**/?(*.)+(spec|test).cjs"
+  ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   // testPathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "bridge.js",
   "scripts": {
     "start": "node src/index.js",
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/interface/dab_operation_timeouts.js
+++ b/src/interface/dab_operation_timeouts.js
@@ -1,0 +1,20 @@
+/**
+ * Keep the existing default request timeout for normal operations, and only
+ * extend timeout for DAB 2.1 operations whose spec latency exceeds the default.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
+
+export const EXTENDED_OPERATION_TIMEOUT_MS = {
+    "applications/install": 60_000,
+    "applications/install-from-app-store": 60_000,
+    "system/factory-reset": 600_000
+};
+
+export function getRequestTimeoutMs(topic, options = {}) {
+    if (typeof options.timeoutMs === "number") {
+        return options.timeoutMs;
+    }
+
+    return EXTENDED_OPERATION_TIMEOUT_MS[topic] ?? DEFAULT_REQUEST_TIMEOUT_MS;
+}
+

--- a/src/lib/mqtt_client/client.js
+++ b/src/lib/mqtt_client/client.js
@@ -18,6 +18,7 @@ import { serializeError } from 'serialize-error';
 import { v4 as uuidv4 } from 'uuid';
 import { TimeoutError } from './error.js';
 import { convertPattern } from './util.js';
+import { getRequestTimeoutMs } from '../../interface/dab_operation_timeouts.js';
 import ee2pkg from 'eventemitter2';
 const { EventEmitter2 } = ee2pkg;
 import {getLogger} from "../util.js";
@@ -59,7 +60,7 @@ const logger = getLogger()
  * @class
  * @private
  */
-class Client {
+export class Client {
 
     #client;
     #emitter;
@@ -203,15 +204,16 @@ class Client {
     const requestTopic = `dab/${this.#deviceId}/${topic}`;
     const responseTopic = `_response/${requestTopic}/${requestId}`;
 
-    const timeout = 20000;
-    options = Object.assign(
+    const { timeoutMs, ...mqttOptions } = options || {};
+    const timeout = getRequestTimeoutMs(topic, { timeoutMs });
+    const publishOptions = Object.assign(
       {
           properties: {
             responseTopic: responseTopic,
             correlationData: requestId
           }
       },
-      options
+      mqttOptions
       );
     
 
@@ -237,7 +239,7 @@ class Client {
         reject(new TimeoutError(`Failed to receive response from ${topic} within ${timeout}ms`));
       }, timeout);
 
-      this.publish(requestTopic, payload, options).catch(reject);
+      this.publish(requestTopic, payload, publishOptions).catch(reject);
     });
   }
 

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -1,4 +1,4 @@
-const { spawn, execSync} = require('child_process');
+import { spawn } from "child_process";
 
 describe("Integration Test of Bridge Device Management Routes", () => {
   let mosquitto_child = null;

--- a/test/mqtt_client_timeouts.test.js
+++ b/test/mqtt_client_timeouts.test.js
@@ -1,0 +1,83 @@
+import { Client } from "../src/lib/mqtt_client/client.js";
+import { getRequestTimeoutMs } from "../src/interface/dab_operation_timeouts.js";
+import { TimeoutError } from "../src/lib/mqtt_client/error.js";
+import { jest } from "@jest/globals";
+
+describe("DAB 2.1 request timeout behavior", () => {
+  test("default timeout remains 20000 ms", () => {
+    expect(getRequestTimeoutMs("applications/list")).toBe(20_000);
+  });
+
+  test("applications/install timeout is 60000 ms", () => {
+    expect(getRequestTimeoutMs("applications/install")).toBe(60_000);
+  });
+
+  test("applications/install-from-app-store timeout is 60000 ms", () => {
+    expect(getRequestTimeoutMs("applications/install-from-app-store")).toBe(60_000);
+  });
+
+  test("system/factory-reset timeout is 600000 ms", () => {
+    expect(getRequestTimeoutMs("system/factory-reset")).toBe(600_000);
+  });
+
+  test("system/network-reset uses default 20000 ms", () => {
+    expect(getRequestTimeoutMs("system/network-reset")).toBe(20_000);
+  });
+
+  test("unknown operations use default 20000 ms", () => {
+    expect(getRequestTimeoutMs("some/unknown-operation")).toBe(20_000);
+  });
+
+  test("options.timeoutMs overrides default and extended timeout", () => {
+    expect(getRequestTimeoutMs("applications/install", { timeoutMs: 12_345 })).toBe(12_345);
+    expect(getRequestTimeoutMs("applications/list", { timeoutMs: 54_321 })).toBe(54_321);
+  });
+
+  test("timeoutMs is stripped before mqtt.publish()", async () => {
+    jest.useFakeTimers();
+
+    const wrapped = {
+      setOnMessage: jest.fn(),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+      end: jest.fn(),
+      publish: jest.fn(() => Promise.resolve()),
+    };
+    const client = new Client(wrapped, "device-1");
+    const reqPromise = client.request(
+      "applications/install",
+      { appId: "x", url: "http://example.com/app" },
+      { qos: 1, timeoutMs: 98765 }
+    );
+
+    await Promise.resolve();
+    expect(wrapped.publish).toHaveBeenCalledTimes(1);
+
+    const publishOptions = wrapped.publish.mock.calls[0][2];
+    expect(publishOptions.timeoutMs).toBeUndefined();
+    expect(publishOptions.qos).toBe(1);
+
+    jest.advanceTimersByTime(98765);
+    await expect(reqPromise).rejects.toBeInstanceOf(TimeoutError);
+    jest.useRealTimers();
+  });
+
+  test("TimeoutError message includes topic and selected timeout", async () => {
+    jest.useFakeTimers();
+
+    const wrapped = {
+      setOnMessage: jest.fn(),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+      end: jest.fn(),
+      publish: jest.fn(() => Promise.resolve()),
+    };
+    const client = new Client(wrapped, "device-1");
+    const reqPromise = client.request("system/factory-reset");
+
+    await Promise.resolve();
+    jest.advanceTimersByTime(600000);
+    await expect(reqPromise).rejects.toThrow("Failed to receive response from system/factory-reset within 600000ms");
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
- add centralized timeout mapping for long-running DAB 2.1 operations
- keep default request timeout at 20000ms for normal operations
- extend only applications/install, applications/install-from-app-store, and system/factory-reset
- support per-request override via options.timeoutMs
- prevent timeoutMs from being forwarded to mqtt publish options
- add timeout unit tests covering defaults, overrides, extended ops, and error messaging
- update test runtime config for ESM-based timeout tests